### PR TITLE
주석 수정 및 Swift6 대응

### DIFF
--- a/Projects/NidThirdPartyLogin/Sources/NidOAuth/NidOAuth.swift
+++ b/Projects/NidThirdPartyLogin/Sources/NidOAuth/NidOAuth.swift
@@ -99,7 +99,7 @@ public class NidOAuth {
     }
 
     /// NidOAuth를 초기화합니다.
-    /// `NidOAuth`를 사용하기 전에, `SceneDelegate`의 `didfinishlaunchingWithOptions`에서 호출해야 합니다.
+    /// `NidOAuth`를 사용하기 전에, `AppDelegate`의 `didfinishlaunchingWithOptions`에서 호출해야 합니다.
     ///
     public func initialize() {
         performInitialSetUp.prepare()

--- a/Projects/NidThirdPartyLoginSample/Tests/NetworkKit/MockURLSessionDataTask.swift
+++ b/Projects/NidThirdPartyLoginSample/Tests/NetworkKit/MockURLSessionDataTask.swift
@@ -9,7 +9,7 @@
 import Foundation
 import NetworkKit
 
-class MockURLSessionDataTask: URLSessionDataTask {
+class MockURLSessionDataTask: URLSessionDataTask, @unchecked Sendable {
     var resumeDidCall: () -> Void = {}
 
     override func resume() {


### PR DESCRIPTION
안녕하세요 iOS개발자 임우섭이라고 합니다
네이버 로그인 잘 사용하고 있습니다! 

최근에 Xcode16.2로 버전업 하면서 의존성 관리중인데
네이버로그인이 objective-c로된 sdk에서 swift로 나온걸 알고 사용중입니다

수정 한 내용은 아래 두가지입니다

1. Naver login sdk 사용중에 주석 오표기가 있어 수정 해봤습니다.
2. Sendable type을(URLSessionDataTask) 상속할경우 상속받은 Class도 @unchecked Sendable을 표기 해야한다고 합니다.

좋은하루 되세요!